### PR TITLE
more liberal acceptance of rowsAffected/insertId

### DIFF
--- a/lib/sqlite/SQLiteDatabase.js
+++ b/lib/sqlite/SQLiteDatabase.js
@@ -22,36 +22,7 @@ function runSelect(db, sql, args, cb) {
   });
 }
 
-function runCreate(db, sql, args, cb) {
-  db.run(sql, args, function (err) {
-    if (err) {
-      return cb(new SQLiteResult(err));
-    }
-    // WebSQL always returns an insertId of 0 for "CREATE TABLE" statements
-    var insertId = 0;
-    var rowsAffected = 0;
-    var rows = [];
-    var resultSet = new SQLiteResult(null, insertId, rowsAffected, rows);
-    cb(resultSet);
-  });
-}
-
-function runDrop(db, sql, args, cb) {
-  db.run(sql, args, function (err) {
-    if (err) {
-      return cb(new SQLiteResult(err));
-    }
-    // WebSQL always returns insertId=undefined and rowsAffected=0
-    // for "DROP TABLE" statements. Go figure.
-    var insertId = void 0;
-    var rowsAffected = 0;
-    var rows = [];
-    var resultSet = new SQLiteResult(null, insertId, rowsAffected, rows);
-    cb(resultSet);
-  });
-}
-
-function runInsert(db, sql, args, cb) {
+function runNonSelect(db, sql, args, cb) {
   db.run(sql, args, function (err) {
     if (err) {
       return cb(new SQLiteResult(err));
@@ -59,21 +30,6 @@ function runInsert(db, sql, args, cb) {
     /* jshint validthis:true */
     var executionResult = this;
     var insertId = executionResult.lastID;
-    var rowsAffected = executionResult.changes;
-    var rows = [];
-    var resultSet = new SQLiteResult(null, insertId, rowsAffected, rows);
-    cb(resultSet);
-  });
-}
-
-function runUpdate(db, sql, args, cb) {
-  db.run(sql, args, function (err) {
-    if (err) {
-      return cb(new SQLiteResult(err));
-    }
-    /* jshint validthis:true */
-    var executionResult = this;
-    var insertId = void 0;
     var rowsAffected = executionResult.changes;
     var rows = [];
     var resultSet = new SQLiteResult(null, insertId, rowsAffected, rows);
@@ -116,22 +72,13 @@ SQLiteDatabase.prototype.exec = function exec(queries, readOnly, callback) {
     // This is inherently error-prone, although it will probably work in the 99%
     // case.
     var isSelect = /^\s*SELECT\b/i.test(sql);
-    var isInsert = /^\s*INSERT\b/i.test(sql);
-    var isCreate = /^\s*CREATE\s+TABLE\b/i.test(sql);
-    var isDrop = /^\s*DROP\s+TABLE\b/i.test(sql);
 
     if (readOnly && !isSelect) {
       onQueryComplete(i)(new SQLiteResult(READ_ONLY_ERROR));
     } else if (isSelect) {
       runSelect(db, sql, args, onQueryComplete(i));
-    } else if (isInsert) {
-      runInsert(db, sql, args, onQueryComplete(i));
-    } else if (isCreate) {
-      runCreate(db, sql, args, onQueryComplete(i));
-    } else if (isDrop) {
-      runDrop(db, sql, args, onQueryComplete(i));
     } else {
-      runUpdate(db, sql, args, onQueryComplete(i));
+      runNonSelect(db, sql, args, onQueryComplete(i));
     }
   }
 

--- a/lib/websql/WebSQLTransaction.js
+++ b/lib/websql/WebSQLTransaction.js
@@ -9,6 +9,32 @@ function errorUnhandled() {
   return true; // a non-truthy return indicates error was handled
 }
 
+// WebSQL has some bizarre behavior regarding insertId/rowsAffected. To try
+// to match the observed behavior of Chrome/Safari as much as possible, we
+// sniff the SQL message to try to massage the returned insertId/rowsAffected.
+// This helps us pass the tests, although it's error-prone and should
+// probably be revised.
+function massageSQLResult(sql, insertId, rowsAffected, rows) {
+  if (/^\s*UPDATE\b/i.test(sql)) {
+    // insertId is always undefined for "UPDATE" statements
+    insertId = void 0;
+  } else if (/^\s*CREATE\s+TABLE\b/i.test(sql)) {
+    // WebSQL always returns an insertId of 0 for "CREATE TABLE" statements
+    insertId = 0;
+    rowsAffected = 0;
+  } else if (/^\s*DROP\s+TABLE\b/i.test(sql)) {
+    // WebSQL always returns insertId=undefined and rowsAffected=0
+    // for "DROP TABLE" statements. Go figure.
+    insertId = void 0;
+    rowsAffected = 0;
+  } else if (!/^\s*INSERT\b/i.test(sql)) {
+    // for all non-inserts (deletes, etc.) insertId is always undefined
+    // ¯\_(ツ)_/¯
+    insertId = void 0;
+  }
+  return new WebSQLResultSet(insertId, rowsAffected, rows);
+}
+
 function SQLTask(sql, args, sqlCallback, sqlErrorCallback) {
   this.sql = sql;
   this.args = args;
@@ -39,8 +65,8 @@ function runBatch(self, batch) {
           return onDone();
         }
       } else {
-        batchTask.sqlCallback(self, new WebSQLResultSet(
-          res.insertId, res.rowsAffected, res.rows));
+        batchTask.sqlCallback(self, massageSQLResult(
+          batch[i].sql, res.insertId, res.rowsAffected, res.rows));
       }
     }
     onDone();


### PR DESCRIPTION
I'm finding it really annoying to get rowsAffected/insertId
exactly right in the native implementations, so I'd prefer
to just munge it in JavaScript so it only has to be
implemented once.