### PR TITLE
avoid transactions when read-only

### DIFF
--- a/lib/websql/WebSQLDatabase.js
+++ b/lib/websql/WebSQLDatabase.js
@@ -44,7 +44,9 @@ WebSQLDatabase.prototype._onTransactionComplete = function(err) {
     self._runNextTransaction();
   }
 
-  if (err) {
+  if (self._currentTask.readOnly) {
+    done(); // read-only doesn't require a transaction
+  } else if (err) {
     self._db.exec(ROLLBACK, false, done);
   } else {
     self._db.exec(COMMIT, false, done);

--- a/lib/websql/WebSQLTransaction.js
+++ b/lib/websql/WebSQLTransaction.js
@@ -114,7 +114,11 @@ function WebSQLTransaction(websqlDatabase) {
   this._complete = false;
   this._runningTimeout = false;
   this._sqlQueue = new Queue();
-  this._sqlQueue.push(new SQLTask('BEGIN;', [], noop, noop));
+  if (!websqlDatabase._currentTask.readOnly) {
+    // Since we serialize all access to the database, there is no need to
+    // run read-only tasks in a transaction. This is a perf boost.
+    this._sqlQueue.push(new SQLTask('BEGIN;', [], noop, noop));
+  }
 }
 
 WebSQLTransaction.prototype.executeSql = function (sql, args, sqlCallback, sqlErrorCallback) {


### PR DESCRIPTION
Since all access to the DB is serialized, there's actually no
need to do an explicit transaction for `readTransaction`s. This is a
perf boost, because it avoids creating an unnecessary transaction,
as well as avoiding a tick for single-shot read transactions. (I.e.
because instead of `BEGIN + SELECT` then `END`, we just have `SELECT`).