### PR TITLE
Escaping of `file::memory:` URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,10 @@ in its indicating that "All strings including the empty string are valid databas
 names" (and that they are case-sensitive), consumers will need to do their
 own mapping for strings in order to 1) avoid problems with invalid filenames or
 filenames on case insensitive file systems, and to 2) avoid user databases being
-given special treatment if the empty string or the string ":memory:" is used.
+given special treatment if the empty string or the string ":memory:" is used;
+another special purpose form of string supported by SQLite that may call for
+escaping are [`file::memory:...`](https://sqlite.org/inmemorydb.html)
+[URLs](https://sqlite.org/uri.html#uri_format).
 
 2. Although neither the WebSQL spec nor SQLite speaks to this matter,
 `node-sqlite3` has the following additional


### PR DESCRIPTION
With the prior changes of 999c0da5a7befb1281382586e600f0275dc4d4a5, this ought to completely fix #19.