### PR TITLE
- Avoid `package-lock.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 testdb*
 coverage
+package-lock.json


### PR DESCRIPTION
Given that you've removed it, it'd be nice not to see the flagging of it in my Git client... Thanks!