### PR TITLE
update sqlite3 to ^5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "argsarray": "^0.0.1",
     "immediate": "^3.2.2",
     "noop-fn": "^1.0.0",
-    "sqlite3": "^4.0.0",
+    "sqlite3": "^5.0.2",
     "tiny-queue": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- npm: update `sqlite3` to ^5.0.2 (4.2.0 binary not found when using ^4.0.0)

I've run the test and 10 tests are failing both before and after changes