### PR TITLE
fix: make sqlite3 an optional dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
     "argsarray": "^0.0.1",
     "immediate": "^3.2.2",
     "noop-fn": "^1.0.0",
-    "sqlite3": "^5.0.2",
     "tiny-queue": "^0.2.1"
+  },
+  "optionalDependencies": {
+    "sqlite3": "^5.0.2"
   },
   "devDependencies": {
     "assert": "1.3.0",


### PR DESCRIPTION
It's possible to use this package without the `sqlite3` package itself (i.e. `custom` mode), so it should be an optional dependency. So if it fails to build on a given platform, you can still use it the other way.