### PR TITLE
Correctly interpret errors stemming from deferred FK constraints

### DIFF
--- a/lib/websql/WebSQLDatabase.js
+++ b/lib/websql/WebSQLDatabase.js
@@ -33,9 +33,19 @@ function WebSQLDatabase(dbVersion, db) {
 WebSQLDatabase.prototype._onTransactionComplete = function(err) {
   var self = this;
 
-  function done() {
-    if (err) {
-      self._currentTask.errorCallback(err);
+  function done(_err, results) {
+    var error = err || null;
+    if (!error && typeof results !== "undefined") {
+      for (var i = 0; i < results.length; i++) {
+        var result = results[i];
+        if (result.error) {
+          error = result.error;
+          break;
+        }
+      }
+    }
+    if (error) {
+      self._currentTask.errorCallback(error);
     } else {
       self._currentTask.successCallback();
     }


### PR DESCRIPTION
This fixes `done` to invoke `errorCallback` when a deferred constraint breaks after a `COMMIT` statement throws an exception.