### PR TITLE
Explicitly roll back transaction on failed commit

### DIFF
--- a/lib/websql/WebSQLDatabase.js
+++ b/lib/websql/WebSQLDatabase.js
@@ -33,17 +33,7 @@ function WebSQLDatabase(dbVersion, db) {
 WebSQLDatabase.prototype._onTransactionComplete = function(err) {
   var self = this;
 
-  function done(rollbackOrCommitError, results) {
-    var error = err || rollbackOrCommitError || null;
-    if (!error && typeof results !== "undefined") {
-      for (var i = 0; i < results.length; i++) {
-        var result = results[i];
-        if (result.error) {
-          error = result.error;
-          break;
-        }
-      }
-    }
+  function done(error) {
     if (error) {
       self._currentTask.errorCallback(error);
     } else {
@@ -54,12 +44,40 @@ WebSQLDatabase.prototype._onTransactionComplete = function(err) {
     self._runNextTransaction();
   }
 
+  function rollbackDone(error) {
+    // Ignoring ROLLBACK errors as per
+    // https://www.sqlite.org/lang_transaction.html#response_to_errors_within_a_transaction
+    return function() {
+      done(error);
+    };
+  }
+
+  function commitDone(commitError, results) {
+    var error = commitError || null;
+    if (!error) {
+      for (var i = 0; i < results.length; i++) {
+        var result = results[i];
+        if (result.error) {
+          error = result.error;
+          break;
+        }
+      }
+    }
+    if (error) {
+      // Explicit ROLLBACK on failed COMMIT as per
+      // https://www.sqlite.org/lang_transaction.html#response_to_errors_within_a_transaction
+      self._db.exec(ROLLBACK, false, rollbackDone(error));
+    } else {
+      done();
+    }
+  }
+
   if (self._currentTask.readOnly) {
-    done(); // read-only doesn't require a transaction
+    done(err); // read-only doesn't require a transaction
   } else if (err) {
-    self._db.exec(ROLLBACK, false, done);
+    self._db.exec(ROLLBACK, false, rollbackDone(err));
   } else {
-    self._db.exec(COMMIT, false, done);
+    self._db.exec(COMMIT, false, commitDone);
   }
 };
 


### PR DESCRIPTION
This is a follow-up for https://github.com/nolanlawson/node-websql/pull/44 which turned out to
be incomplete: SQLite doesn't always automatically roll back
transactions when commit fails. The patch expands the respective test
case to demonstrate this. Without the fix, the last assertion would
fail since the transaction that errored out on commit before would
still be active and silently re-used by the next transaction, which
would then end up seeing its temporary (and inconsistent) state.

The patch is based on the following recommendation from the manual[1]:

> It is recommended that applications respond to the errors listed
> above by explicitly issuing a ROLLBACK command. If the transaction
> has already been rolled back automatically by the error response,
> then the ROLLBACK command will fail with an error, but no harm is
> caused by this.

The "errors listed above" here refer to errors which don't
automatically roll back the transaction. Irritatingly, the error used
in the test case (invalid deferred fk constraints) is not listed
there. The manual states this about it[2]:

> Deferred foreign key constraints are not checked until the
> transaction tries to COMMIT. For as long as the user has an open
> transaction, the database is allowed to exist in a state that
> violates any number of deferred foreign key constraints. However,
> COMMIT will fail as long as foreign key constraints remain in
> violation.

Which hints at the fact that the transaction is not rolled back
automatically. Now since the WebSQL API doesn't provide a way to
gracefully recover from this situation (i.e. the transaction object is
not passed into the error callback), always rolling back seems to be
the most reasonable behavior in the spirit of the spec.

1: https://www.sqlite.org/lang_transaction.html#response_to_errors_within_a_transaction
2: https://www.sqlite.org/foreignkeys.html#fk_deferred